### PR TITLE
Change uses of ES to OS in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-# AWS ES Connection
+# AWS OpenSearch Connection
 
-AWS ES connection for the new OpenSearch client (@opensearch-project/opensearch)
+AWS OpenSearch Connection library for the new OpenSearch client (@opensearch-project/opensearch).
 
 Thanks to [ChristopherGillis](https://github.com/ChristopherGillis) and as well as the contributors to the [Acuris version](https://github.com/mergermarket/acuris-aws-es-connection) of this library. I've simply added an action to release this updated OpenSearch version to NPM. I'll continue to maintain this as needed, though hopefully AWS intergrates this directly into their client at some point.
 
 PRs/Issues welcome.
-
 
 ## Installation
 
@@ -68,7 +67,7 @@ This package creates a Connection class that signs the requests to AWS OpenSearc
 
 Make sure that your AWS credentials are available to your env, for example you could set them in your ENV.
 
-You need a running AWS ES instance for the tests to run against. Set the endpoint URL as the env `AWS_ES_ENDPOINT`.
+You need a running AWS OpenSearch instance for the tests to run against. Set the endpoint URL as the env `AWS_ES_ENDPOINT`.
 
 ```bash
 AWS_ES_ENDPOINT=https://xxxx.es.amazonaws.com yarn test


### PR DESCRIPTION
This is somewhat of a trivial change, but 1) it's a bit confusing on github and npmjs to see:

<img width="508" alt="image" src="https://github.com/mattwilkinsonn/aws-os-connection/assets/124996/d45ea780-1840-4b30-851f-a7eadc604f90">

and 2) I think this is one reason why searching for this in google does't result in a link:

<img width="879" alt="image" src="https://github.com/mattwilkinsonn/aws-os-connection/assets/124996/6eac070b-baaf-421d-9f98-edeea888af62">
